### PR TITLE
Fix for another cause of issue #413

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -193,7 +193,7 @@ uis.directive('uiSelect',
         if (appendToBody !== undefined ? appendToBody : uiSelectConfig.appendToBody) {
           scope.$watch('$select.open', function(isOpen) {
             if (isOpen) {
-              positionDropdown();
+              $timeout(positionDropdown);
             } else {
               resetDropdown();
             }


### PR DESCRIPTION
I was experiencing a "scope.$digest() was called when $digest already in progress" on the first click on the ui-select.  It was caused because ng-model's onBlur was getting called due to the call to $document.find('body').append(element);

I was using angular 3.3.15 on Chrome
